### PR TITLE
Refactor Field/MethodSignature constructors

### DIFF
--- a/bombe-asm/src/main/java/me/jamiemansfield/bombe/asm/analysis/ClassNodeClassInfo.java
+++ b/bombe-asm/src/main/java/me/jamiemansfield/bombe/asm/analysis/ClassNodeClassInfo.java
@@ -51,10 +51,10 @@ class ClassNodeClassInfo extends InheritanceProvider.ClassInfo.Impl {
         );
         this.interfaces.addAll(klass.interfaces);
         klass.fields.stream()
-                .map(fieldNode -> new FieldSignature(fieldNode.name, fieldNode.desc))
+                .map(fieldNode -> FieldSignature.of(fieldNode.name, fieldNode.desc))
                 .forEach(this.fields::add);
         klass.methods.stream()
-                .map(methodNode -> new MethodSignature(methodNode.name, methodNode.desc))
+                .map(methodNode -> MethodSignature.of(methodNode.name, methodNode.desc))
                 .forEach(this.methods::add);
     }
 

--- a/bombe-core/src/main/java/me/jamiemansfield/bombe/type/signature/FieldSignature.java
+++ b/bombe-core/src/main/java/me/jamiemansfield/bombe/type/signature/FieldSignature.java
@@ -47,6 +47,18 @@ public class FieldSignature extends MemberSignature {
     private final FieldType type;
 
     /**
+     * Creates a new field signature with the given name and
+     * decoded type descriptor.
+     *
+     * @param name The name of the field
+     * @param type The raw type of the field
+     * @return The new field signature
+     */
+    public static FieldSignature of(String name, String type) {
+        return new FieldSignature(name, FieldType.of(type));
+    }
+
+    /**
      * Creates a field signature, with the given name and type.
      *
      * @param name The name of the field
@@ -58,23 +70,13 @@ public class FieldSignature extends MemberSignature {
     }
 
     /**
-     * Creates a field signature, with the given name and type.
-     *
-     * @param name The name of the field
-     * @param type The type of the field
-     */
-    public FieldSignature(final String name, final String type) {
-        this(name, FieldType.of(type));
-    }
-
-    /**
      * Creates a field signature, with the given name.
      *
      * @param name The name of the field
      * @since 0.1.1
      */
     public FieldSignature(final String name) {
-        this(name, (FieldType) null);
+        this(name, null);
     }
 
     /**

--- a/bombe-core/src/main/java/me/jamiemansfield/bombe/type/signature/MethodSignature.java
+++ b/bombe-core/src/main/java/me/jamiemansfield/bombe/type/signature/MethodSignature.java
@@ -46,6 +46,29 @@ public class MethodSignature extends MemberSignature {
     private final MethodDescriptor descriptor;
 
     /**
+     * Creates a method signature, with the given method name and raw descriptor.
+     *
+     * @param name The method name
+     * @param descriptor The method's raw descriptor
+     * @return The new method signature
+     */
+    public static MethodSignature of(final String name, final String descriptor) {
+        return new MethodSignature(name, MethodDescriptor.of(descriptor));
+    }
+
+    /**
+     * Creates a method signature, with the given raw string that contains the
+     * method name and descriptor concatenated.
+     *
+     * @param nameAndDescriptor The method name and descriptor
+     * @return The new method signature
+     */
+    public static MethodSignature of(final String nameAndDescriptor) {
+        int methodIndex = nameAndDescriptor.indexOf('(');
+        return of(nameAndDescriptor.substring(0, methodIndex), nameAndDescriptor.substring(methodIndex));
+    }
+
+    /**
      * Creates a method signature, with the given name and {@link MethodDescriptor}.
      *
      * @param name The method name
@@ -54,16 +77,6 @@ public class MethodSignature extends MemberSignature {
     public MethodSignature(final String name, final MethodDescriptor descriptor) {
         super(name);
         this.descriptor = descriptor;
-    }
-
-    /**
-     * Creates a method descriptor, with the given method name and raw descriptor.
-     *
-     * @param name The method name
-     * @param descriptor The method's raw descriptor
-     */
-    public MethodSignature(final String name, final String descriptor) {
-        this(name, MethodDescriptor.of(descriptor));
     }
 
     /**


### PR DESCRIPTION
Right now they are rather confusing in my opinion. `MethodDescriptor` uses `of` for the method that does additional parsing, but `FieldSignature` and `MethodSignature` have it directly in their constructor.

I think having it in `Field/MethodSignature.of` as well makes it more clear that additional parsing is done there. I've also added `MethodSignature.of(String nameAndDescriptor)` which accepts a concatenated method name and descriptor (e.g. `isChunkLoaded(IIZ)Z`) 