### PR TITLE
Rework inheritance providers 

### DIFF
--- a/bombe-asm/build.gradle
+++ b/bombe-asm/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
     compile project(':bombe')
     compile 'org.ow2.asm:asm-commons:6.2'
-    compile 'com.github.ben-manes.caffeine:caffeine:2.6.2'
 }

--- a/bombe-asm/src/main/java/me/jamiemansfield/bombe/asm/analysis/InheritanceClassInfoVisitor.java
+++ b/bombe-asm/src/main/java/me/jamiemansfield/bombe/asm/analysis/InheritanceClassInfoVisitor.java
@@ -1,0 +1,56 @@
+package me.jamiemansfield.bombe.asm.analysis;
+
+import me.jamiemansfield.bombe.analysis.InheritanceProvider;
+import me.jamiemansfield.bombe.analysis.InheritanceType;
+import me.jamiemansfield.bombe.type.signature.FieldSignature;
+import me.jamiemansfield.bombe.type.signature.MethodSignature;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class InheritanceClassInfoVisitor extends ClassVisitor {
+
+    private String name;
+    private boolean isInterface;
+    private String superName;
+    private List<String> interfaces = Collections.emptyList();
+
+    private final Map<FieldSignature, InheritanceType> fields = new HashMap<>();
+    private final Map<MethodSignature, InheritanceType> methods = new HashMap<>();
+
+    InheritanceClassInfoVisitor() {
+        super(Opcodes.ASM6);
+    }
+
+    InheritanceProvider.ClassInfo create() {
+        return new InheritanceProvider.ClassInfo.Impl(this.name, this.isInterface, this.superName, this.interfaces, this.fields, this.methods);
+    }
+
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        this.name = name;
+        this.isInterface = (access & Opcodes.ACC_INTERFACE) != 0;
+        this.superName = superName;
+        this.interfaces = Arrays.asList(interfaces);
+    }
+
+    @Override
+    public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+        this.fields.put(FieldSignature.of(name, descriptor), InheritanceType.fromModifiers(access));
+        return null;
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+        this.methods.put(MethodSignature.of(name, descriptor), InheritanceType.fromModifiers(access));
+        return null;
+    }
+
+}

--- a/bombe-asm/src/main/java/me/jamiemansfield/bombe/asm/analysis/SourceSetInheritanceProvider.java
+++ b/bombe-asm/src/main/java/me/jamiemansfield/bombe/asm/analysis/SourceSetInheritanceProvider.java
@@ -30,12 +30,16 @@
 
 package me.jamiemansfield.bombe.asm.analysis;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
 import me.jamiemansfield.bombe.analysis.InheritanceProvider;
+import me.jamiemansfield.bombe.analysis.InheritanceType;
 import me.jamiemansfield.bombe.asm.jar.SourceSet;
+import me.jamiemansfield.bombe.type.signature.FieldSignature;
+import me.jamiemansfield.bombe.type.signature.MethodSignature;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * An {@link InheritanceProvider} that obtains all of its information
@@ -46,23 +50,25 @@ import java.util.Optional;
  */
 public class SourceSetInheritanceProvider implements InheritanceProvider {
 
-    private final LoadingCache<String, ClassInfo> cache;
+    private final SourceSet sources;
 
     public SourceSetInheritanceProvider(final SourceSet sources) {
-        this.cache = Caffeine.newBuilder()
-                .build(key -> {
-                    if (sources.has(key)) {
-                        return new ClassNodeClassInfo(sources.get(key));
-                    }
-                    else {
-                        return null;
-                    }
-                });
+        this.sources = sources;
     }
 
     @Override
     public Optional<ClassInfo> provide(final String klass) {
-        return Optional.ofNullable(this.cache.get(klass));
+        if (this.sources.has(klass)) {
+            ClassNode node = this.sources.get(klass);
+            return Optional.of(new ClassInfo.Impl(node.name, (node.access & Opcodes.ACC_INTERFACE) != 0, node.superName, node.interfaces,
+                    node.fields.stream()
+                            .collect(Collectors.toMap(f -> FieldSignature.of(f.name, f.desc), f -> InheritanceType.fromModifiers(f.access))),
+                    node.methods.stream()
+                            .collect(Collectors.toMap(m -> MethodSignature.of(m.name, m.desc), m -> InheritanceType.fromModifiers(m.access)))
+            ));
+        } else {
+            return Optional.empty();
+        }
     }
 
 }

--- a/bombe/src/main/java/me/jamiemansfield/bombe/analysis/CascadingInheritanceProvider.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/analysis/CascadingInheritanceProvider.java
@@ -74,4 +74,13 @@ public class CascadingInheritanceProvider implements InheritanceProvider {
         return Optional.empty();
     }
 
+    @Override
+    public Optional<ClassInfo> provide(String klass, Object context) {
+        for (final InheritanceProvider provider : this.providers) {
+            final Optional<ClassInfo> info = provider.provide(klass, context);
+            if (info.isPresent()) return info;
+        }
+        return Optional.empty();
+    }
+
 }

--- a/bombe/src/main/java/me/jamiemansfield/bombe/analysis/InheritanceCompletable.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/analysis/InheritanceCompletable.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2018, Jamie Mansfield <https://jamiemansfield.me/>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package me.jamiemansfield.bombe.analysis;
+
+import java.util.Optional;
+
+/**
+ * Represents a class that can be completed by using resolving inheritance,
+ * e.g. by inheriting attributes from parent classes.
+ *
+ * @author Minecrell
+ * @since 0.3.0
+ */
+public interface InheritanceCompletable {
+
+    /**
+     * Provide the appropriate {@link InheritanceProvider.ClassInfo}
+     * for this class.
+     *
+     * @param provider The provider to use for looking up the class
+     * @param context Optional context for the inheritance provider
+     * @return The inheritance class info, wrapped in an {@link Optional}
+     */
+    Optional<InheritanceProvider.ClassInfo> provideInheritance(InheritanceProvider provider, Object context);
+
+    /**
+     * Returns whether this class was already completed using inheritance.
+     *
+     * @return If this class is complete
+     */
+    boolean isComplete();
+
+    /**
+     * Attempts to complete this class using the provided
+     * {@link InheritanceProvider}.
+     *
+     * @param provider The provider to use for looking up the class
+     */
+    default void complete(InheritanceProvider provider) {
+        complete(provider, (Object) null);
+    }
+
+    /**
+     * Attempts to complete this class using the provided
+     * {@link InheritanceProvider}.
+     *
+     * @param provider The provider to use for looking up the class
+     * @param context Optional context for the inheritance provider
+     */
+    default void complete(InheritanceProvider provider, Object context) {
+        if (isComplete()) {
+            return;
+        }
+
+        Optional<InheritanceProvider.ClassInfo> info = provideInheritance(provider, context);
+        info.ifPresent(classInfo -> complete(provider, classInfo));
+    }
+
+    /**
+     * Attempts to complete this class using the provided
+     * {@link InheritanceProvider}.
+     *
+     * @param provider The provider to use for looking up parent classes
+     * @param info The resolve inheritance class info for this class
+     */
+    void complete(InheritanceProvider provider, InheritanceProvider.ClassInfo info);
+
+}

--- a/bombe/src/main/java/me/jamiemansfield/bombe/analysis/InheritanceProvider.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/analysis/InheritanceProvider.java
@@ -33,11 +33,14 @@ package me.jamiemansfield.bombe.analysis;
 import me.jamiemansfield.bombe.type.signature.FieldSignature;
 import me.jamiemansfield.bombe.type.signature.MethodSignature;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * An inheritance provider stores inheritance information on classes, which
@@ -57,22 +60,20 @@ public interface InheritanceProvider {
      */
     Optional<ClassInfo> provide(final String klass);
 
-    default List<String> getParentsOf(final String klass) {
-        return this.getParentsOf(klass, new ArrayList<>());
-    }
-
-    default List<String> getParentsOf(final String klass, final List<String> parents) {
-        final Consumer<String> addParent = parent -> {
-            if (!parents.contains(parent)) {
-                parents.add(parent);
-                parents.addAll(this.getParentsOf(parent, parents));
-            }
-        };
-        this.provide(klass).ifPresent(info -> {
-            if (info.getSuperName() != null) addParent.accept(info.getSuperName());
-            info.getInterfaces().forEach(addParent);
-        });
-        return parents;
+    /**
+     * Gets the class information for the given class name and optional context, if available.
+     *
+     * <p>The provided context may be used by the {@link InheritanceProvider} to avoid
+     * looking up the class by its name. The accepted values are specific to each
+     * {@link InheritanceProvider}; unknown context should be ignored.</p>
+     *
+     * @param klass The class name
+     * @param context Additional context related to the class name
+     * @return The class information wrapped in an {@link Optional}
+     * @since 0.3.0
+     */
+    default Optional<ClassInfo> provide(final String klass, Object context) {
+        return provide(klass);
     }
 
     /**
@@ -88,52 +89,253 @@ public interface InheritanceProvider {
         String getName();
 
         /**
+         * Gets the package name of the class.
+         *
+         * @return The package name
+         * @since 0.3.0
+         */
+        default String getPackage() {
+            final String name = this.getName();
+            final int classIndex = name.lastIndexOf('/');
+            return classIndex >= 0 ? name.substring(0, classIndex) : "";
+        }
+
+        /**
+         * Gets whether the represented class is an interface.
+         *
+         * @return {@code true} if the class is an interface
+         * @since 0.3.0
+         */
+        boolean isInterface();
+
+        /**
          * Gets the name of this class' super class.
+         *
+         * <p>Returns an empty string for interfaces or {@link Object}.</p>
          *
          * @return The super name
          */
         String getSuperName();
 
         /**
-         * Gets an immutable-view of all the interfaces of the class.
+         * Gets an unmodifiable view of all the <i>direct</i> interfaces of the class.
          *
          * @return The class' interfaces
          */
         List<String> getInterfaces();
 
         /**
-         * Gets an immutable-view of all the fields of the class.
+         * Gets an unmodifiable view of all fields declared in the class.
+         * It does not include fields inherited from parent classes.
          *
-         * @return The class' fields
+         * @return The declared fields
          */
-        List<FieldSignature> getFields();
+        Map<FieldSignature, InheritanceType> getFields();
 
         /**
-         * Gets an immutable-view of all the methods.
+         * Gets an unmodifiable view of all methods declared in the class.
+         * It does not include methods inherited from parent classes.
          *
-         * @return The methods
+         * @return The declared methods
          */
-        List<MethodSignature> getMethods();
+        Map<MethodSignature, InheritanceType> getMethods();
 
         /**
-         * A default implementation of {@link ClassInfo}.
+         * Gets an unmodifiable view of all parents of this class, recursively.
+         *
+         * <p>If a class in the inheritance chain cannot be provided by the
+         * given {@link InheritanceProvider} it will be missing in the result,
+         * along with all its parent classes.</p>
+         *
+         * @param provider The provider to use for looking up parent classes
+         * @return A set with all parents of the class (recursively)
+         * @since 0.3.0
          */
-        abstract class Impl implements ClassInfo {
+        default Set<ClassInfo> provideParents(InheritanceProvider provider) {
+            Set<ClassInfo> result = new HashSet<>();
+            provideParents(provider, result);
+            return Collections.unmodifiableSet(result);
+        }
+
+        /**
+         * Populates the given collection with all parents of this class, recursively.
+         *
+         * <p>If a class in the inheritance chain cannot be provided by the
+         * given {@link InheritanceProvider} it will be missing in the result,
+         * along with all its parent classes.</p>
+         *
+         * @param provider The provider to use for looking up parent classes
+         * @param parents The collection to populate
+         * @since 0.3.0
+         */
+        default void provideParents(InheritanceProvider provider, Collection<ClassInfo> parents) {
+            provider.provide(getSuperName()).ifPresent(p -> {
+                parents.add(p);
+                p.provideParents(provider, parents);
+            });
+            for (String iface : getInterfaces()) {
+                provider.provide(iface).ifPresent(p -> {
+                    parents.add(p);
+                    p.provideParents(provider, parents);
+                });
+            }
+        }
+
+        /**
+         * Returns whether this class has another class as a parent.
+         *
+         * <p>This method may return unexpected results if a class in
+         * the inheritance chain cannot be provided by the given
+         * {@link InheritanceProvider}.</p>
+         *
+         * @param klass The class to search in the parents of this class
+         * @param provider The provider to use for looking up parent classes
+         * @return {@code true} if this class inherits from the specified class
+         */
+        default boolean hasParent(String klass, InheritanceProvider provider) {
+            return provideParents(provider).stream().map(ClassInfo::getName).anyMatch(Predicate.isEqual(klass));
+        }
+
+        /**
+         * Returns whether this class has another class as a parent.
+         *
+         * <p>This method may return unexpected results if a class in
+         * the inheritance chain cannot be provided by the given
+         * {@link InheritanceProvider}.</p>
+         *
+         * @param info The class to search in the parents of this class
+         * @param provider The provider to use for looking up parent classes
+         * @return {@code true} if this class inherits from the specified class
+         */
+        default boolean hasParent(ClassInfo info, InheritanceProvider provider) {
+            return provideParents(provider).contains(info);
+        }
+
+        /**
+         * Returns whether the given child class could inherit the given field
+         * from this parent class.
+         *
+         * <p>Note: This method does not check if the given class actually
+         * extends this class or interface.
+         * Use {@link #hasParent(ClassInfo, InheritanceProvider)} to check this
+         * additionally if necessary.</p>
+         *
+         * @param child The child class to check
+         * @param field The field to check
+         * @return If the child class could inherit the field
+         * @since 0.3.0
+         */
+        default boolean canInherit(ClassInfo child, FieldSignature field) {
+            return getFields().getOrDefault(field, InheritanceType.NONE).canInherit(this, child);
+        }
+
+        /**
+         * Returns whether the given child class could inherit the given method
+         * from this parent class.
+         *
+         * <p>Note: This method does not check if the given class actually
+         * extends this class or interface.
+         * Use {@link #hasParent(ClassInfo, InheritanceProvider)} to check this
+         * additionally if necessary.</p>
+         *
+         * @param child The child class to check
+         * @param method The method to check
+         * @return If the child class could inherit the method
+         * @since 0.3.0
+         */
+        default boolean canInherit(ClassInfo child, MethodSignature method) {
+            return getMethods().getOrDefault(method, InheritanceType.NONE).canInherit(this, child);
+        }
+
+        /**
+         * Returns a new {@link ClassInfo} that caches the information
+         * returned by the getters in this interface.
+         *
+         * <p>This method is intended for usage by {@link InheritanceProvider}s
+         * to simplify their implementation. All {@link ClassInfo} provided
+         * by an {@link InheritanceProvider} <i>should</i> be lazy initialized
+         * or otherwise cached.</p>
+         *
+         * @return A lazy class info
+         */
+        default ClassInfo lazy() {
+            return new LazyInheritanceClassInfo(this);
+        }
+
+        /**
+         * Abstract base implementation for {@link ClassInfo} that provides
+         * a standard implementation of {@link #equals(Object)},
+         * {@link #hashCode()} and {@link #toString()}.
+         *
+         * <p>All {@link ClassInfo} <i>should</i> implement these methods
+         * as specified in this class.</p>
+         */
+        abstract class Abstract implements ClassInfo {
+
+            @Override
+            public final boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (!(o instanceof ClassInfo)) {
+                    return false;
+                }
+
+                ClassInfo other = (ClassInfo) o;
+                return getName().equals(other.getName());
+            }
+
+            @Override
+            public final int hashCode() {
+                return getName().hashCode();
+            }
+
+            @Override
+            public String toString() {
+                return "ClassInfo{" +
+                        "name='" + getName() + '\'' +
+                        ", interface=" + isInterface() +
+                        ", superName='" + getSuperName() + '\'' +
+                        ", interfaces=" + getInterfaces() +
+                        ", fields=" + getFields() +
+                        ", methods=" + getMethods() +
+                        '}';
+            }
+
+        }
+
+        /**
+         * A default, simple implementation of {@link ClassInfo}.
+         */
+        class Impl extends Abstract implements ClassInfo {
 
             protected final String name;
+            protected final boolean isInterface;
             protected final String superName;
-            protected final List<String> interfaces = new ArrayList<>();
-            protected final List<FieldSignature> fields = new ArrayList<>();
-            protected final List<MethodSignature> methods = new ArrayList<>();
+            protected final List<String> interfaces;
+            protected final Map<FieldSignature, InheritanceType> fields;
+            protected final Map<MethodSignature, InheritanceType> methods;
 
-            protected Impl(final String name, final String superName) {
+            protected Set<ClassInfo> parents;
+
+            public Impl(final String name, boolean isInterface, final String superName, List<String> interfaces,
+                    Map<FieldSignature, InheritanceType> fields, Map<MethodSignature, InheritanceType> methods) {
                 this.name = name;
-                this.superName = superName;
+                this.isInterface = isInterface;
+                this.superName = superName != null ? superName : "";
+                this.interfaces = Collections.unmodifiableList(interfaces);
+                this.fields = Collections.unmodifiableMap(fields);
+                this.methods = Collections.unmodifiableMap(methods);
             }
 
             @Override
             public String getName() {
                 return this.name;
+            }
+
+            @Override
+            public boolean isInterface() {
+                return this.isInterface;
             }
 
             @Override
@@ -143,17 +345,35 @@ public interface InheritanceProvider {
 
             @Override
             public List<String> getInterfaces() {
-                return Collections.unmodifiableList(this.interfaces);
+                return this.interfaces;
             }
 
             @Override
-            public List<FieldSignature> getFields() {
-                return Collections.unmodifiableList(this.fields);
+            public Map<FieldSignature, InheritanceType> getFields() {
+                return this.fields;
             }
 
             @Override
-            public List<MethodSignature> getMethods() {
-                return Collections.unmodifiableList(this.methods);
+            public Map<MethodSignature, InheritanceType> getMethods() {
+                return this.methods;
+            }
+
+            @Override
+            public Set<ClassInfo> provideParents(InheritanceProvider provider) {
+                if (this.parents == null) {
+                    this.parents = ClassInfo.super.provideParents(provider);
+                }
+                return this.parents;
+            }
+
+            @Override
+            public void provideParents(InheritanceProvider provider, Collection<ClassInfo> parents) {
+                parents.addAll(provideParents(provider));
+            }
+
+            @Override
+            public ClassInfo lazy() {
+                return this; // Impl has all values computed already
             }
 
         }

--- a/bombe/src/main/java/me/jamiemansfield/bombe/analysis/InheritanceProvider.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/analysis/InheritanceProvider.java
@@ -222,7 +222,7 @@ public interface InheritanceProvider {
          *
          * @param child The child class to check
          * @param field The field to check
-         * @return If the child class could inherit the field
+         * @return {@code true} if the child class could inherit the method
          * @since 0.3.0
          */
         default boolean canInherit(ClassInfo child, FieldSignature field) {
@@ -240,11 +240,32 @@ public interface InheritanceProvider {
          *
          * @param child The child class to check
          * @param method The method to check
-         * @return If the child class could inherit the method
+         * @return {@code true} if the child class could inherit the method
          * @since 0.3.0
          */
         default boolean canInherit(ClassInfo child, MethodSignature method) {
             return getMethods().getOrDefault(method, InheritanceType.NONE).canInherit(this, child);
+        }
+
+        /**
+         * Returns whether this class overrides the specified method in the
+         * given parent class.
+         *
+         * <p>Note: This method does not check if the given class actually
+         * extends this class or interface.
+         * Use {@link #hasParent(ClassInfo, InheritanceProvider)} to check this
+         * additionally if necessary.</p>
+         *
+         * @param method The method to check
+         * @param parent The parent class to check
+         * @return {@code true} if this class overrides the method
+         */
+        default boolean overrides(MethodSignature method, ClassInfo parent) {
+            InheritanceType own = getMethods().getOrDefault(method, InheritanceType.NONE);
+            if (own == InheritanceType.NONE) return false;
+
+            InheritanceType parentType = parent.getMethods().getOrDefault(method, InheritanceType.NONE);
+            return own.compareTo(parentType) >= 0 && parentType.canInherit(parent, this);
         }
 
         /**

--- a/bombe/src/main/java/me/jamiemansfield/bombe/analysis/LazyInheritanceClassInfo.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/analysis/LazyInheritanceClassInfo.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2018, Jamie Mansfield <https://jamiemansfield.me/>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package me.jamiemansfield.bombe.analysis;
+
+import me.jamiemansfield.bombe.type.signature.FieldSignature;
+import me.jamiemansfield.bombe.type.signature.MethodSignature;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+final class LazyInheritanceClassInfo extends InheritanceProvider.ClassInfo.Abstract {
+
+    private final InheritanceProvider.ClassInfo provider;
+
+    // Cached data
+    private final String name;
+    private String superName;
+    private List<String> interfaces;
+    private Map<FieldSignature, InheritanceType> fields;
+    private Map<MethodSignature, InheritanceType> methods;
+    private Set<InheritanceProvider.ClassInfo> parents;
+
+    LazyInheritanceClassInfo(InheritanceProvider.ClassInfo provider) {
+        this.provider = provider;
+        this.name = provider.getName();
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public boolean isInterface() {
+        return this.provider.isInterface();
+    }
+
+    @Override
+    public String getSuperName() {
+        if (this.superName == null) {
+            this.superName = this.provider.getSuperName();
+        }
+        return this.superName;
+    }
+
+    @Override
+    public List<String> getInterfaces() {
+        if (this.interfaces == null) {
+            this.interfaces = this.provider.getInterfaces();
+        }
+        return this.interfaces;
+    }
+
+    @Override
+    public Map<FieldSignature, InheritanceType> getFields() {
+        if (this.fields == null) {
+            this.fields = this.provider.getFields();
+        }
+        return this.fields;
+    }
+
+    @Override
+    public Map<MethodSignature, InheritanceType> getMethods() {
+        if (this.methods == null) {
+            this.methods = this.provider.getMethods();
+        }
+        return this.methods;
+    }
+
+    @Override
+    public Set<InheritanceProvider.ClassInfo> provideParents(InheritanceProvider provider) {
+        if (this.parents == null) {
+            this.parents = this.provider.provideParents(provider);
+        }
+
+        return this.parents;
+    }
+
+    @Override
+    public void provideParents(InheritanceProvider provider, Collection<InheritanceProvider.ClassInfo> parents) {
+        parents.addAll(provideParents(provider));
+    }
+
+    @Override
+    public InheritanceProvider.ClassInfo lazy() {
+        return this;
+    }
+
+}

--- a/bombe/src/main/java/me/jamiemansfield/bombe/analysis/ReflectionInheritanceProvider.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/analysis/ReflectionInheritanceProvider.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2018, Jamie Mansfield <https://jamiemansfield.me/>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package me.jamiemansfield.bombe.analysis;
+
+import me.jamiemansfield.bombe.type.signature.FieldSignature;
+import me.jamiemansfield.bombe.type.signature.MethodSignature;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * A simple implementation of {@link InheritanceProvider} based on Java's
+ * reflection API.
+ *
+ * @author Minecrell
+ * @since 0.3.0
+ */
+public class ReflectionInheritanceProvider implements InheritanceProvider {
+
+    private final ClassLoader classLoader;
+
+    public ReflectionInheritanceProvider(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    public Optional<ClassInfo> provide(String klass) {
+        try {
+            return Optional.of(provide(Class.forName(klass.replace('/', '.'), false, this.classLoader)));
+        } catch (ClassNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<ClassInfo> provide(String klass, Object context) {
+        if (context instanceof Class) {
+            // Avoid looking up class if it is provided in context
+            return Optional.of(provide((Class<?>) context));
+        } else {
+            return provide(klass);
+        }
+    }
+
+    public ClassInfo provide(Class<?> clazz) {
+        return new ReflectionClassInfo(clazz).lazy();
+    }
+
+    private static class ReflectionClassInfo extends ClassInfo.Abstract {
+
+        private final Class<?> clazz;
+
+        private ReflectionClassInfo(Class<?> clazz) {
+            this.clazz = clazz;
+        }
+
+        private static String getInternalName(Class<?> clazz) {
+            return clazz.getName().replace('.', '/');
+        }
+
+        @Override
+        public String getName() {
+            return getInternalName(this.clazz);
+        }
+
+        @Override
+        public boolean isInterface() {
+            return this.clazz.isInterface();
+        }
+
+        @Override
+        public String getSuperName() {
+            Class<?> superClass = this.clazz.getSuperclass();
+            return superClass != null ? getInternalName(superClass) : "";
+        }
+
+        @Override
+        public List<String> getInterfaces() {
+            return Collections.unmodifiableList(Arrays.stream(this.clazz.getInterfaces())
+                    .map(ReflectionClassInfo::getInternalName)
+                    .collect(Collectors.toList()));
+        }
+
+        @Override
+        public Map<FieldSignature, InheritanceType> getFields() {
+            return Collections.unmodifiableMap(Arrays.stream(this.clazz.getDeclaredFields())
+                    .collect(Collectors.toMap(FieldSignature::of, f -> InheritanceType.fromModifiers(f.getModifiers()))));
+        }
+
+        @Override
+        public Map<MethodSignature, InheritanceType> getMethods() {
+            return Collections.unmodifiableMap(Arrays.stream(this.clazz.getDeclaredMethods())
+                    .collect(Collectors.toMap(MethodSignature::of, m -> InheritanceType.fromModifiers(m.getModifiers()))));
+        }
+
+        private void provideParent(InheritanceProvider provider, Class<?> parent, Collection<ClassInfo> parents) {
+            if (parent == null) {
+                return;
+            }
+
+            ClassInfo parentInfo = provider.provide(getInternalName(parent), parent).orElse(null);
+            if (parentInfo != null) {
+                parentInfo.provideParents(provider, parents);
+                parents.add(parentInfo);
+            }
+        }
+
+        @Override
+        public void provideParents(InheritanceProvider provider, Collection<ClassInfo> parents) {
+            provideParent(provider, this.clazz.getSuperclass(), parents);
+            for (Class<?> iface : this.clazz.getInterfaces()) {
+                provideParent(provider, iface, parents);
+            }
+        }
+
+    }
+
+}

--- a/bombe/src/main/java/me/jamiemansfield/bombe/type/FieldType.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/type/FieldType.java
@@ -63,33 +63,32 @@ public interface FieldType extends Type {
         if (klass.isPrimitive()) {
             if (klass == Boolean.TYPE) {
                 return BaseType.BOOLEAN;
-            }
-            else if (klass == Character.TYPE) {
+            } else if (klass == Character.TYPE) {
                 return BaseType.CHAR;
-            }
-            else if (klass == Byte.TYPE) {
+            } else if (klass == Byte.TYPE) {
                 return BaseType.BYTE;
-            }
-            else if (klass == Short.TYPE) {
+            } else if (klass == Short.TYPE) {
                 return BaseType.SHORT;
-            }
-            else if (klass == Integer.TYPE) {
+            } else if (klass == Integer.TYPE) {
                 return BaseType.INT;
-            }
-            else if (klass == Long.TYPE) {
+            } else if (klass == Long.TYPE) {
                 return BaseType.LONG;
-            }
-            else if (klass == Float.TYPE) {
+            } else if (klass == Float.TYPE) {
                 return BaseType.FLOAT;
-            }
-            else if (klass == Double.TYPE) {
+            } else if (klass == Double.TYPE) {
                 return BaseType.DOUBLE;
-            }
-            else {
+            } else {
                 throw new RuntimeException("Invalid base type: " + klass.getName());
             }
-        }
-        else {
+        } else if (klass.isArray()) {
+            int dimensions = 0;
+            Class<?> componentType = klass;
+            do {
+                componentType = componentType.getComponentType();
+                dimensions++;
+            } while (componentType.isArray());
+            return new ArrayType(dimensions, of(componentType));
+        } else {
             return new ObjectType(klass.getName());
         }
     }

--- a/bombe/src/main/java/me/jamiemansfield/bombe/type/MethodDescriptor.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/type/MethodDescriptor.java
@@ -30,9 +30,12 @@
 
 package me.jamiemansfield.bombe.type;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * A model of a method descriptor, a text representation of a method's
@@ -60,6 +63,13 @@ public final class MethodDescriptor {
      */
     public static MethodDescriptor of(final String descriptor) {
         return new MethodDescriptorReader(descriptor).read();
+    }
+
+    public static MethodDescriptor of(final Method method) {
+        return new MethodDescriptor(
+                Arrays.stream(method.getParameterTypes()).map(FieldType::of).collect(Collectors.toList()),
+                Type.of(method.getReturnType())
+        );
     }
 
     /**

--- a/bombe/src/main/java/me/jamiemansfield/bombe/type/ObjectType.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/type/ObjectType.java
@@ -33,6 +33,7 @@ package me.jamiemansfield.bombe.type;
 import me.jamiemansfield.bombe.analysis.InheritanceProvider;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Represents an object type within Java.
@@ -71,9 +72,11 @@ public class ObjectType implements FieldType {
         if (this == obj) return true;
         if (!(obj instanceof ObjectType)) return false;
         final ObjectType that = (ObjectType) obj;
-        return this.equals(that) ||
-                that.getClassName().equals("java/lang/Object") ||
-                inheritanceProvider.getParentsOf(this.className).contains(that.getClassName());
+        if (this.equals(that) || this.className.equals("java/lang/Object")) return true;
+
+        // Check inheritance
+        Optional<InheritanceProvider.ClassInfo> info = inheritanceProvider.provide(that.getClassName());
+        return info.isPresent() && info.get().hasParent(this.className, inheritanceProvider);
     }
 
     @Override

--- a/bombe/src/main/java/me/jamiemansfield/bombe/type/Type.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/type/Type.java
@@ -62,7 +62,7 @@ public interface Type {
      * @return The type
      */
     static Type of(final Class<?> klass) {
-        if (klass.isPrimitive() && klass == Void.TYPE) {
+        if (klass == Void.TYPE) {
             return VoidType.INSTANCE;
         }
         return FieldType.of(klass);

--- a/bombe/src/main/java/me/jamiemansfield/bombe/type/signature/FieldSignature.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/type/signature/FieldSignature.java
@@ -32,6 +32,7 @@ package me.jamiemansfield.bombe.type.signature;
 
 import me.jamiemansfield.bombe.type.FieldType;
 
+import java.lang.reflect.Field;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -56,6 +57,10 @@ public class FieldSignature extends MemberSignature {
      */
     public static FieldSignature of(String name, String type) {
         return new FieldSignature(name, FieldType.of(type));
+    }
+
+    public static FieldSignature of(Field field) {
+        return new FieldSignature(field.getName(), FieldType.of(field.getType()));
     }
 
     /**

--- a/bombe/src/main/java/me/jamiemansfield/bombe/type/signature/MethodSignature.java
+++ b/bombe/src/main/java/me/jamiemansfield/bombe/type/signature/MethodSignature.java
@@ -32,6 +32,7 @@ package me.jamiemansfield.bombe.type.signature;
 
 import me.jamiemansfield.bombe.type.MethodDescriptor;
 
+import java.lang.reflect.Method;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -66,6 +67,10 @@ public class MethodSignature extends MemberSignature {
     public static MethodSignature of(final String nameAndDescriptor) {
         int methodIndex = nameAndDescriptor.indexOf('(');
         return of(nameAndDescriptor.substring(0, methodIndex), nameAndDescriptor.substring(methodIndex));
+    }
+
+    public static MethodSignature of(final Method method) {
+        return new MethodSignature(method.getName(), MethodDescriptor.of(method));
     }
 
     /**

--- a/bombe/src/test/java/me/jamiemansfield/bombe/analysis/ReflectionInheritanceProviderTest.java
+++ b/bombe/src/test/java/me/jamiemansfield/bombe/analysis/ReflectionInheritanceProviderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018, Jamie Mansfield <https://jamiemansfield.me/>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package me.jamiemansfield.bombe.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import me.jamiemansfield.bombe.type.signature.MethodSignature;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+public abstract class ReflectionInheritanceProviderTest {
+
+    protected final InheritanceProvider provider;
+
+    protected ReflectionInheritanceProviderTest(InheritanceProvider provider) {
+        this.provider = provider;
+    }
+
+    @Test
+    public void testObject(InheritanceProvider provider) {
+        InheritanceProvider.ClassInfo info = provider.provide("java/lang/Object").get();
+        assertEquals(info.getName(), "java/lang/Object");
+        assertEquals(info.getPackage(), "java/lang");
+        assertFalse(info.isInterface());
+        assertEquals(info.getSuperName(), "");
+        assertEquals(info.getInterfaces(), Collections.emptyList());
+    }
+
+    @Test
+    public void testList(InheritanceProvider provider) {
+        InheritanceProvider.ClassInfo info = provider.provide("java/util/List").get();
+        assertEquals(info.getName(), "java/util/List");
+        assertEquals(info.getPackage(), "java/util");
+        assertTrue(info.isInterface());
+        assertEquals(info.getSuperName(), "");
+        assertEquals(info.getInterfaces(), Collections.singletonList("java/util/Collection"));
+
+        assertEquals(info.getMethods().get(MethodSignature.of("isEmpty()Z")), InheritanceType.PUBLIC);
+    }
+
+    @Test
+    public void testArrayList(InheritanceProvider provider) {
+        InheritanceProvider.ClassInfo info = provider.provide("java/util/ArrayList").get();
+        assertEquals(info.getName(), "java/util/ArrayList");
+        assertEquals(info.getPackage(), "java/util");
+        assertEquals(info.getSuperName(), "java/util/AbstractList");
+
+        // Interfaces should not be recursive
+        assertFalse(info.getInterfaces().contains("java/util/Collection"));
+        assertTrue(info.getInterfaces().contains("java/util/RandomAccess"));
+
+        assertEquals(info.getMethods().get(MethodSignature.of("grow(I)V")), InheritanceType.NONE);
+    }
+
+}

--- a/changelogs/0.3.0.md
+++ b/changelogs/0.3.0.md
@@ -9,3 +9,19 @@ that can be used further afield than Lorenz or Survey.
 - The `bombe-core` module has been renamed to simply `bombe`, becoming more inline with the
   Lorenz modules.
 - `Type#isInstanceof` has been renamed to `Type#isAssignableFrom`.
+
+### Inheritance providers
+`InheritanceProvider` has been reworked to expose inheritance access levels (represented
+by `InheritanceType`) and to improve performance.
+
+- `InheritanceProvider.ClassInfo#getFields` and `getMethods` now return a
+  `Map<*Signature, InheritanceType>` that allows checking if a child class actually inherits
+  a member from its parent class based on its access level.
+- `InheritanceProvider.ClassInfo#provideParents` is a shortcut to provide `ClassInfo`s for all
+  parent classes/interfaces for a class, recursively. (Replaces the `getParentsOf` method)
+- There is a new `CachingInheritanceProvider` that wraps an existing `InheritanceProvider` and
+  caches the request. This replaces the duplicated functionality in all other
+  `InheritanceProvider` implementations.
+- `ReflectionInheritanceProvider` was added as a reference implementation based on Java's
+  reflection API.
+ 


### PR DESCRIPTION
The changes are mostly explained in the changelog, see https://github.com/CadixDev/Bombe/compare/develop...Minecrell:inheritance?expand=1#diff-ceb901f9815babfe0118fe5ef7cd1f14

`InheritanceCompletable` is a common interface shared by Lorenz and the upcoming AT lib for completion. Avoids some duplication.

I think this is in a merge-able state now, but there will likely be more improvements in the future. 