### PR TITLE
Make Bombe work in a modular environment

### DIFF
--- a/bombe-jar/build.gradle
+++ b/bombe-jar/build.gradle
@@ -3,3 +3,9 @@ dependencies {
     compileOnly "org.ow2.asm:asm-commons:$asmVersion"
     testCompile "org.ow2.asm:asm-commons:$asmVersion"
 }
+
+jar {
+    manifest.attributes(
+      'Automatic-Module-Name': "${project.group}.bombe.jar"
+    )
+}

--- a/bombe/build.gradle
+++ b/bombe/build.gradle
@@ -3,3 +3,10 @@ dependencies {
     compileOnly "org.ow2.asm:asm-commons:$asmVersion"
     testCompile "org.ow2.asm:asm-commons:$asmVersion"
 }
+
+jar {
+    manifest.attributes(
+      'Automatic-Module-Name': "${project.group}.bombe"
+    )
+}
+

--- a/bombe/src/main/java/org/cadixdev/bombe/analysis/asm/ClassProviderInheritanceProvider.java
+++ b/bombe/src/main/java/org/cadixdev/bombe/analysis/asm/ClassProviderInheritanceProvider.java
@@ -31,7 +31,7 @@
 package org.cadixdev.bombe.analysis.asm;
 
 import org.cadixdev.bombe.analysis.InheritanceProvider;
-import org.cadixdev.bombe.jar.ClassProvider;
+import org.cadixdev.bombe.provider.ClassProvider;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
 

--- a/bombe/src/main/java/org/cadixdev/bombe/provider/ClassLoaderClassProvider.java
+++ b/bombe/src/main/java/org/cadixdev/bombe/provider/ClassLoaderClassProvider.java
@@ -28,7 +28,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.cadixdev.bombe.jar;
+package org.cadixdev.bombe.provider;
 
 import org.cadixdev.bombe.util.ByteStreams;
 

--- a/bombe/src/main/java/org/cadixdev/bombe/provider/ClassProvider.java
+++ b/bombe/src/main/java/org/cadixdev/bombe/provider/ClassProvider.java
@@ -28,7 +28,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.cadixdev.bombe.jar;
+package org.cadixdev.bombe.provider;
 
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.tree.ClassNode;

--- a/bombe/src/main/java/org/cadixdev/bombe/provider/JarFileClassProvider.java
+++ b/bombe/src/main/java/org/cadixdev/bombe/provider/JarFileClassProvider.java
@@ -28,7 +28,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.cadixdev.bombe.jar;
+package org.cadixdev.bombe.provider;
 
 import org.cadixdev.bombe.util.ByteStreams;
 


### PR DESCRIPTION
This PR adds an `Automatic-Module-Name` metadata field to each artifact, so that `bombe` can be used in a modular environment.

Because JPMS prohibits split packages (classes in the same package but in multiple jars/modules), the `jar` package in one of the projects will have to change names. That makes this PR a **breaking** change. I chose another name for the package in the main project, but that is of course open to changes.