### PR TITLE
Basic multi-release jar handling

### DIFF
--- a/bombe-jar/src/main/java/org/cadixdev/bombe/jar/JarClassEntry.java
+++ b/bombe-jar/src/main/java/org/cadixdev/bombe/jar/JarClassEntry.java
@@ -42,6 +42,11 @@ public class JarClassEntry extends AbstractJarEntry {
 
     private final byte[] contents;
 
+    public JarClassEntry(final int version, final String unversionedName, final long time, final byte[] contents) {
+        super(version, unversionedName, time);
+        this.contents = contents;
+    }
+
     public JarClassEntry(final String name, final long time, final byte[] contents) {
         super(name, time);
         this.contents = contents;
@@ -58,8 +63,8 @@ public class JarClassEntry extends AbstractJarEntry {
     }
 
     @Override
-    public final JarClassEntry accept(final JarEntryTransformer vistor) {
-        return vistor.transform(this);
+    public final JarClassEntry accept(final JarEntryTransformer visitor) {
+        return visitor.transform(this);
     }
 
 }

--- a/bombe-jar/src/main/java/org/cadixdev/bombe/jar/JarManifestEntry.java
+++ b/bombe-jar/src/main/java/org/cadixdev/bombe/jar/JarManifestEntry.java
@@ -78,8 +78,8 @@ public class JarManifestEntry extends AbstractJarEntry {
     }
 
     @Override
-    public JarManifestEntry accept(final JarEntryTransformer vistor) {
-        return vistor.transform(this);
+    public JarManifestEntry accept(final JarEntryTransformer visitor) {
+        return visitor.transform(this);
     }
 
 }

--- a/bombe-jar/src/main/java/org/cadixdev/bombe/jar/JarResourceEntry.java
+++ b/bombe-jar/src/main/java/org/cadixdev/bombe/jar/JarResourceEntry.java
@@ -42,6 +42,11 @@ public class JarResourceEntry extends AbstractJarEntry {
     private final byte[] contents;
     private String extension;
 
+    public JarResourceEntry(final int version, final String unversionedName, final long time, final byte[] contents) {
+        super(version, unversionedName, time);
+        this.contents = contents;
+    }
+
     public JarResourceEntry(final String name, final long time, final byte[] contents) {
         super(name, time);
         this.contents = contents;
@@ -61,8 +66,8 @@ public class JarResourceEntry extends AbstractJarEntry {
     }
 
     @Override
-    public final JarResourceEntry accept(final JarEntryTransformer vistor) {
-        return vistor.transform(this);
+    public final JarResourceEntry accept(final JarEntryTransformer visitor) {
+        return visitor.transform(this);
     }
 
 }

--- a/bombe-jar/src/main/java/org/cadixdev/bombe/jar/JarServiceProviderConfigurationEntry.java
+++ b/bombe-jar/src/main/java/org/cadixdev/bombe/jar/JarServiceProviderConfigurationEntry.java
@@ -79,8 +79,8 @@ public class JarServiceProviderConfigurationEntry extends AbstractJarEntry {
     }
 
     @Override
-    public final JarServiceProviderConfigurationEntry accept(final JarEntryTransformer vistor) {
-        return vistor.transform(this);
+    public final JarServiceProviderConfigurationEntry accept(final JarEntryTransformer visitor) {
+        return visitor.transform(this);
     }
 
 }

--- a/bombe-jar/src/main/java/org/cadixdev/bombe/jar/asm/JarEntryRemappingTransformer.java
+++ b/bombe-jar/src/main/java/org/cadixdev/bombe/jar/asm/JarEntryRemappingTransformer.java
@@ -85,9 +85,9 @@ public class JarEntryRemappingTransformer implements JarEntryTransformer {
         ), 0);
 
         // Create the jar entry
-        final String originalName = entry.getName().substring(0, entry.getName().length() - ".class".length());
+        final String originalName = entry.getUnversionedName().substring(0, entry.getUnversionedName().length() - ".class".length());
         final String name = this.remapper.map(originalName) + ".class";
-        return new JarClassEntry(name, entry.getTime(), writer.toByteArray());
+        return new JarClassEntry(entry.getVersion(), name, entry.getTime(), writer.toByteArray());
     }
 
     @Override

--- a/bombe-jar/src/test/groovy/org/cadixdev/bombe/jar/test/asm/JarEntryRemappingTransformerSpec.groovy
+++ b/bombe-jar/src/test/groovy/org/cadixdev/bombe/jar/test/asm/JarEntryRemappingTransformerSpec.groovy
@@ -80,6 +80,28 @@ class JarEntryRemappingTransformerSpec extends Specification {
         node.name == 'pkg/Demo'
     }
 
+    def "remaps multi-release class"() {
+        given:
+        // Create a test class
+        def obf = new ClassWriter(0)
+        obf.visit(Opcodes.V9, Opcodes.ACC_PUBLIC, 'a', null, 'java/lang/Object', null)
+
+        // Run it through the transformer
+        def entry = TRANSFORMER.transform(new JarClassEntry('META-INF/versions/9/a.class', 0, obf.toByteArray()))
+
+        // Use a ClassNode for convenience
+        def node = new ClassNode()
+        def reader = new ClassReader(entry.contents)
+        reader.accept(node, 0)
+
+        expect:
+        entry.name == 'META-INF/versions/9/pkg/Demo.class'
+        entry.version == 9
+        entry.unversionedName == 'pkg/Demo.class'
+        node.name == 'pkg/Demo'
+
+    }
+
     def "remaps manifest"() {
         given:
         // Create a test Manifest


### PR DESCRIPTION
This adds multi-release jar handling to the model and
updates the remapping transformer to be aware of that information.

There are a few things I'm unsure of here:

- What should the default name of a jar entry be? Currently the name is the raw name to maintain existing behavior, but the JDK's `JarEntry` uses the version-stripped name as default, exposing the raw name as the [real name](https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/util/jar/JarEntry.html#getRealName())
- Naming? does "unversioned" name make sense?
- Does it make sense to add any special handling to Atlas? With these model changes atlas shouldn't need any changes to function, but it might be nice to add multi-release aware lookup methods to the atlas `JarFile`. Especially in its role as a `ClassProvider`, it might be helpful for Atlas to be aware of multi-release jars.